### PR TITLE
Feature/hooks and triggers

### DIFF
--- a/main.c
+++ b/main.c
@@ -14,6 +14,7 @@
 #include "tinydb_tcp_client_handler.h"
 #include "tinydb_tcp_server.h"
 #include "tinydb_thread_pool.h"
+#include "tinydb_webhook.h"
 
 RuntimeContext* context = NULL;
 
@@ -81,7 +82,7 @@ main(int argc, char const* argv[])
   DB_Log(DB_LOG_INFO, "RuntimeContext has been allocated and initialized.");
 
 #if 1
-  context->user_manager.users = (DB_User*) malloc(sizeof(DB_User));
+  context->user_manager.users = (DB_User*)malloc(sizeof(DB_User));
   context->user_manager.users[0].ID = 0;
   context->user_manager.users[0].name = "default";
   context->user_manager.users[0].access = (DB_Access*)malloc(sizeof(DB_Access));
@@ -97,13 +98,21 @@ main(int argc, char const* argv[])
   if (!context->Active.db->name) {
     context->Active.db->name = "default";
   }
-  DB_Log(DB_LOG_INFO, "Default Database (%s) has been assigned.", context->Active.db->name);
+  DB_Log(DB_LOG_INFO,
+         "Default Database (%s) has been assigned.",
+         context->Active.db->name);
 
   TCP_Server tcp_server = { 0 };
   TCP_Client tcp_client = { 0 };
 
+  Add_Webhook("@hook_test", "https://webhook.site/2b054855-6a59-4e30-abaa-0c76d6522c84");
+  Add_Webhook("@hook_test", "http://localhost/webhook");
+
+  List_Webhooks("@hook_test");
+
   TCP_Server_Create(&tcp_server);
-  DB_Log(DB_LOG_INFO, "TCP Server has been initialized.", context->Active.db->name);
+  DB_Log(
+    DB_LOG_INFO, "TCP Server has been initialized.", context->Active.db->name);
   DB_Log(DB_LOG_INFO, " - Host: %s", "127.0.0.1");
   DB_Log(DB_LOG_INFO, " - Port: %d", PORT);
 

--- a/project_config.json
+++ b/project_config.json
@@ -1,0 +1,8 @@
+{
+  "build_command" : "make -C `echo $(pwd)` -B",
+  "format_on_save": true,
+  "formatter": {
+    "bin": "clang-format",
+    "style": "Mozilla"
+  }
+}

--- a/tinydb_pubsub.h
+++ b/tinydb_pubsub.h
@@ -40,13 +40,22 @@ Subscribe(PubSubSystem* system, const char* channel_name, int32_t socket_fd);
 void
 Unsubscribe(PubSubSystem* system, const char* channel_name, int32_t socket_fd);
 
+void
+Unsubscribe_All(PubSubSystem* system, int32_t socket_fd);
+
 Channel*
 Find_Channel(PubSubSystem* system, const char* channel_name);
+
+void
+Remove_Empty_Channel(PubSubSystem* system, const char* channel_name);
 
 void
 Publish(PubSubSystem* system, const char* channel_name, const char* message);
 
 void
 Send_Message(void* socket_desc);
+
+void
+Destroy_PubSub_System(PubSubSystem* system);
 
 #endif // __TINY_DB_PUBSUB

--- a/tinydb_webhook.c
+++ b/tinydb_webhook.c
@@ -1,0 +1,216 @@
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tinydb_context.h"
+#include "tinydb_log.h"
+#include "tinydb_thread_pool.h"
+#include "tinydb_webhook.h"
+
+#define MAX_RESPONSE_SIZE 4096
+#define MAX_REQUEST_SIZE 2048
+
+extern RuntimeContext* context;
+
+void
+Add_Webhook(const char* channel_name, const char* url)
+{
+  if (strncmp(channel_name, "@hook", 5) != 0) {
+    DB_Log(
+      DB_LOG_ERROR, "Cannot add webhook to non-hook channel: %s", channel_name);
+    return;
+  }
+
+  DatabaseEntry entry = DB_Atomic_Get(context->Active.db, channel_name);
+  HPLinkedList* webhook_list;
+
+  if (entry.type == DB_ENTRY_LIST) {
+    webhook_list = entry.value.list;
+  } else {
+    webhook_list = HPList_Create();
+    DB_Value value = { .list = webhook_list };
+    DB_Atomic_Store(context->Active.db, channel_name, value, DB_ENTRY_LIST);
+  }
+
+  HPList_RPush_String(webhook_list, url);
+}
+
+void
+Remove_Webhook(const char* channel_name, const char* url)
+{
+  if (strncmp(channel_name, "@hook", 5) != 0) {
+    DB_Log(DB_LOG_ERROR,
+           "Cannot remove webhook from non-hook channel: %s",
+           channel_name);
+    return;
+  }
+
+  DatabaseEntry entry = DB_Atomic_Get(context->Active.db, channel_name);
+  if (entry.type == DB_ENTRY_LIST) {
+    HPLinkedList* webhook_list = entry.value.list;
+    // todo (David) implement HPList_Remove_String for HList
+    // HPList_Remove_String(webhook_list, url);
+  }
+}
+
+void
+List_Webhooks(const char* channel_name)
+{
+  if (strncmp(channel_name, "@hook", 5) != 0) {
+    printf("Not a hook channel: %s\n", channel_name);
+    return;
+  }
+
+  DatabaseEntry entry = DB_Atomic_Get(context->Active.db, channel_name);
+  if (entry.type == DB_ENTRY_LIST) {
+    HPLinkedList* webhook_list = entry.value.list;
+    printf("Webhooks for channel %s:\n", channel_name);
+    ListNode* node = webhook_list->head;
+    while (node != NULL) {
+      if (node->type == TYPE_STRING) {
+        printf("- %s\n", node->value.string_value);
+      }
+      node = node->next;
+    }
+  } else {
+    printf("No webhooks found for channel %s\n", channel_name);
+  }
+}
+
+void
+Trigger_Webhooks(const char* channel_name, const char* message)
+{
+  if (strncmp(channel_name, "@hook", 5) != 0) {
+    return; // not a hook channel
+  }
+
+  DatabaseEntry entry = DB_Atomic_Get(context->Active.db, channel_name);
+  if (entry.type == DB_ENTRY_LIST) {
+    HPLinkedList* webhook_list = entry.value.list;
+    ListNode* node = webhook_list->head;
+    while (node != NULL) {
+      if (node->type == TYPE_STRING) {
+        WebhookArgs* args = (WebhookArgs*)malloc(sizeof(WebhookArgs));
+        strncpy(args->url, node->value.string_value, MAX_URL_LENGTH);
+        args->message = strdup(message);
+        Thread_Pool_Add_Task(Send_Webhook, (void*)args);
+      }
+      node = node->next;
+    }
+  }
+}
+
+static void
+Send_Webhook(void* args)
+{
+  WebhookArgs* webhook_args = (WebhookArgs*)args;
+  char* json_string = malloc(sizeof(char) * MAX_REQUEST_SIZE);
+  sprintf(json_string,
+          "{\"event\": \"%s\", \"data\": \"%s\"}",
+          webhook_args->message,
+          "Hello, Sailor!");
+
+  Send_Http_Post(webhook_args->url, json_string);
+  free(json_string);
+  free(webhook_args->message);
+  free(webhook_args);
+}
+
+// todo (David) this do not support SSL (for now we are only parsing the schema https)
+void
+Send_Http_Post(const char* url, const char* json_data)
+{
+  char schema[6];
+  char host[256];
+  char path[256];
+  int port = 80;
+
+  if (sscanf(url, "%5[^:]://%255[^/]%255s", schema, host, path) < 2) {
+    DB_Log(DB_LOG_ERROR, "Failed to parse URL: %s", url);
+    return;
+  }
+
+  if (strcmp(schema, "https") == 0) {
+    port = 443;
+  } else if (strcmp(schema, "http") != 0) {
+    DB_Log(DB_LOG_ERROR, "Unsupported schema: %s", schema);
+    return;
+  }
+
+  char* colon = strchr(host, ':');
+  if (colon != NULL) {
+    *colon = '\0';
+    port = atoi(colon + 1);
+  }
+
+  if (path[0] == '\0') {
+    strcpy(path, "/");
+  }
+
+  int32_t sock;
+  struct sockaddr_in server_addr;
+  struct hostent* host_info;
+
+  sock = socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) {
+    DB_Log(DB_LOG_ERROR, "Socket creation failed");
+    return;
+  }
+
+  host_info = gethostbyname(host);
+  if (host_info == NULL) {
+    DB_Log(DB_LOG_ERROR, "Could not resolve host %s", host);
+    close(sock);
+    return;
+  }
+
+  memset(&server_addr, 0, sizeof(server_addr));
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(port);
+  memcpy(&server_addr.sin_addr.s_addr, host_info->h_addr, host_info->h_length);
+
+  if (connect(sock, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+    DB_Log(DB_LOG_ERROR, "Connection failed to %s://%s:%d", schema, host, port);
+    close(sock);
+    return;
+  }
+
+  char request[MAX_REQUEST_SIZE];
+  snprintf(request,
+           sizeof(request),
+           "POST %s HTTP/1.1\r\n"
+           "Host: %s\r\n"
+           "Content-Type: application/json\r\n"
+           "Content-Length: %zu\r\n"
+           "Connection: close\r\n"
+           "\r\n"
+           "%s",
+           path,
+           host,
+           strlen(json_data),
+           json_data);
+
+  if (send(sock, request, strlen(request), 0) < 0) {
+    DB_Log(
+      DB_LOG_ERROR, "Failed to send request to %s://%s:%d", schema, host, port);
+    close(sock);
+    return;
+  }
+
+  char response[MAX_RESPONSE_SIZE];
+  int bytes_received = recv(sock, response, sizeof(response) - 1, 0);
+  if (bytes_received > 0) {
+    response[bytes_received] = '\0';
+    DB_Log(DB_LOG_INFO,
+           "Webhook response from %s://%s:%d: %s",
+           schema,
+           host,
+           port,
+           response);
+  }
+
+  close(sock);
+}

--- a/tinydb_webhook.h
+++ b/tinydb_webhook.h
@@ -1,0 +1,32 @@
+#ifndef __TINY_DB_WEBHOOK
+#define __TINY_DB_WEBHOOK
+
+#include "tinydb_atomic_proc.h"
+#include "tinydb_list.h"
+
+#define MAX_URL_LENGTH 256
+
+typedef struct
+{
+  char url[MAX_URL_LENGTH];
+  char* message;
+} WebhookArgs;
+
+static void
+Send_Http_Post(const char* url, const char* json_data);
+
+static void
+Send_Webhook(void* args);
+
+void
+Add_Webhook(const char* channel_name, const char* url);
+
+void
+Remove_Webhook(const char* channel_name, const char* url);
+void
+List_Webhooks(const char* channel_name);
+
+void
+Trigger_Webhooks(const char* channel_name, const char* message);
+
+#endif // __TINY_DB_WEBHOOK


### PR DESCRIPTION
- HTTP/1.1 post method implementation 
- Special channels with @hook_ prefix
- Hook URLs stored in list @hook_ prefix
- Empty channel clean up

how to use automatic hooks

Store Webhook URLs in the HList that will have @hook_{channel name} in this case @hook_mychannel

```sh
RPUSH @hook_mychannel http://myserver.com/webhook
RPUSH @hook_mychannel http://myserver2.com/webhook
RPUSH @hook_mychannel http://myserver3.com/webhook
```

Create a default subscriber for the channel (the publisher also can act as a subscriber) 
```sh
SUB @hook_mychannel
```

Publish the event to the channel
```sh
PUB @hook_mychannel my.event data_str
```

After publishing the event to the channel @hook_mychannel

All the webhook servers that are listed in the **hook_mychannel** list will be sent with the following data

```json
{
   "event": "my.event",
   "data": "..."
}
```

What's next
- HTTPS support
- hook messages

